### PR TITLE
Stop re-publishing joint states

### DIFF
--- a/franka_control/launch/franka_control.launch
+++ b/franka_control/launch/franka_control.launch
@@ -22,10 +22,4 @@
     <rosparam unless="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states] </rosparam>
     <param name="rate" value="30"/>
   </node>
-  <node name="joint_state_desired_publisher" type="joint_state_publisher" pkg="joint_state_publisher" output="screen">
-    <rosparam if="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states_desired, franka_gripper/joint_states] </rosparam>
-    <rosparam unless="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states_desired] </rosparam>
-    <param name="rate" value="30"/>
-    <remap from="/joint_states" to="/joint_states_desired" />
-  </node>
 </launch>

--- a/franka_control/launch/franka_control.launch
+++ b/franka_control/launch/franka_control.launch
@@ -5,6 +5,10 @@
 
   <param name="robot_description" command="$(find xacro)/xacro $(find franka_description)/robots/panda_arm.urdf.xacro hand:=$(arg load_gripper)" />
 
+  <!-- Remap both, arm and gripper joint states to default ROS topic joint_states -->
+  <remap from="franka_state_controller/joint_states" to="joint_states" />
+  <remap from="franka_gripper/joint_states" to="joint_states" />
+
   <include file="$(find franka_gripper)/launch/franka_gripper.launch" if="$(arg load_gripper)">
     <arg name="robot_ip" value="$(arg robot_ip)" />
   </include>
@@ -17,9 +21,4 @@
   <rosparam command="load" file="$(find franka_control)/config/default_controllers.yaml" />
   <node name="state_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="franka_state_controller"/>
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen"/>
-  <node name="joint_state_publisher" type="joint_state_publisher" pkg="joint_state_publisher" output="screen">
-    <rosparam if="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states, franka_gripper/joint_states] </rosparam>
-    <rosparam unless="$(arg load_gripper)" param="source_list">[franka_state_controller/joint_states] </rosparam>
-    <param name="rate" value="30"/>
-  </node>
 </launch>

--- a/franka_description/robots/dual_panda_example.urdf.xacro
+++ b/franka_description/robots/dual_panda_example.urdf.xacro
@@ -26,11 +26,11 @@
   </link>
 
   <!-- right arm with gripper -->
-  <xacro:panda_arm arm_id="$(arg arm_id_1)" connected_to="base"  xyz="0 -0.5 1" safety_distance="0.03"/>
+  <xacro:panda_arm arm_id="$(arg arm_id_1)" ns="$(arg arm_id_1)" connected_to="base" xyz="0 -0.5 1" safety_distance="0.03" />
   <xacro:hand ns="$(arg arm_id_1)" rpy="0 0 ${-pi/4}" connected_to="$(arg arm_id_1)_link8" safety_distance="0.03"/>
 
   <!-- left arm with gripper -->
-  <xacro:panda_arm arm_id="$(arg arm_id_2)" connected_to="base"  xyz="0 0.5 1" safety_distance="0.03"/>
+  <xacro:panda_arm arm_id="$(arg arm_id_2)" ns="$(arg arm_id_2)" connected_to="base" xyz="0 0.5 1" safety_distance="0.03" />
   <xacro:hand ns="$(arg arm_id_2)" rpy="0 0 ${-pi/4}" connected_to="$(arg arm_id_2)_link8" safety_distance="0.03"/>
 
 </robot>

--- a/franka_description/robots/panda_arm.urdf.xacro
+++ b/franka_description/robots/panda_arm.urdf.xacro
@@ -5,16 +5,14 @@
   <xacro:arg name="hand"   default="false" /> <!-- Should a franka_gripper be mounted at the flange?" -->
   <xacro:arg name="gazebo" default="false" /> <!-- Is the robot being simulated in gazebo?" -->
 
-  <xacro:property name="arm_id" value="$(arg arm_id)" />
-
   <xacro:unless value="$(arg gazebo)">
     <!-- Create a URDF for a real hardware -->
     <xacro:include filename="$(find franka_description)/robots/panda_arm.xacro" />
-    <xacro:panda_arm arm_id="${arm_id}" safety_distance="0.03"/>
+    <xacro:panda_arm arm_id="$(arg arm_id)" safety_distance="0.03"/>
 
     <xacro:if value="$(arg hand)">
       <xacro:include filename="$(find franka_description)/robots/hand.xacro"/>
-      <xacro:hand ns="${arm_id}" rpy="0 0 ${-pi/4}" connected_to="${arm_id}_link8" safety_distance="0.03"/>
+      <xacro:hand ns="$(arg arm_id)" rpy="0 0 ${-pi/4}" connected_to="$(arg arm_id)_link8" safety_distance="0.03"/>
     </xacro:if>
   </xacro:unless>
 
@@ -27,12 +25,12 @@
     <xacro:include filename="$(find franka_description)/robots/utils.xacro" />
     <xacro:include filename="$(find franka_description)/robots/panda_gazebo.xacro" />
 
-    <xacro:panda_arm arm_id="${arm_id}" />
+    <xacro:panda_arm arm_id="$(arg arm_id)" />
 
     <xacro:if value="$(arg hand)">
-      <xacro:hand ns="${arm_id}" rpy="0 0 ${-pi/4}" connected_to="${arm_id}_link8" />
-      <xacro:gazebo-joint joint="${arm_id}_finger_joint1" transmission="hardware_interface/EffortJointInterface" />
-      <xacro:gazebo-joint joint="${arm_id}_finger_joint2" transmission="hardware_interface/EffortJointInterface" />
+      <xacro:hand ns="$(arg arm_id)" rpy="0 0 ${-pi/4}" connected_to="$(arg arm_id)_link8" />
+      <xacro:gazebo-joint joint="$(arg arm_id)_finger_joint1" transmission="hardware_interface/EffortJointInterface" />
+      <xacro:gazebo-joint joint="$(arg arm_id)_finger_joint2" transmission="hardware_interface/EffortJointInterface" />
     </xacro:if>
 
     <!-- Gazebo requires a joint to a link called "world" for statically mounted robots -->
@@ -40,27 +38,27 @@
     <joint name="world_joint" type="fixed">
       <origin xyz="$(arg xyz)" rpy="$(arg rpy)" />
       <parent link="world" />
-      <child  link="${arm_id}_link0" />
+      <child  link="$(arg arm_id)_link0" />
     </joint>
 
 
-    <xacro:gazebo-joint joint="${arm_id}_joint1" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="${arm_id}_joint2" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="${arm_id}_joint3" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="${arm_id}_joint4" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="${arm_id}_joint5" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="${arm_id}_joint6" transmission="hardware_interface/EffortJointInterface" />
-    <xacro:gazebo-joint joint="${arm_id}_joint7" transmission="hardware_interface/EffortJointInterface" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint1" transmission="hardware_interface/EffortJointInterface" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint2" transmission="hardware_interface/EffortJointInterface" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint3" transmission="hardware_interface/EffortJointInterface" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint4" transmission="hardware_interface/EffortJointInterface" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint5" transmission="hardware_interface/EffortJointInterface" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint6" transmission="hardware_interface/EffortJointInterface" />
+    <xacro:gazebo-joint joint="$(arg arm_id)_joint7" transmission="hardware_interface/EffortJointInterface" />
 
-    <xacro:transmission-franka-state arm_id="${arm_id}" />
-    <xacro:transmission-franka-model arm_id="${arm_id}"
-       root="${arm_id}_joint1"
-       tip="${arm_id}_joint8"
+    <xacro:transmission-franka-state arm_id="$(arg arm_id)" />
+    <xacro:transmission-franka-model arm_id="$(arg arm_id)"
+       root="$(arg arm_id)_joint1"
+       tip="$(arg arm_id)_joint8"
      />
 
     <gazebo>
       <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-        <robotNamespace>${arm_id}</robotNamespace>
+        <robotNamespace>$(arg arm_id)</robotNamespace>
         <controlPeriod>0.001</controlPeriod>
         <robotSimType>franka_gazebo/FrankaHWSim</robotSimType>
       </plugin>

--- a/franka_description/robots/panda_arm.urdf.xacro
+++ b/franka_description/robots/panda_arm.urdf.xacro
@@ -1,9 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="panda">
 
-  <xacro:arg name="arm_id" default="panda" /> <!-- Name of this panda -->
-  <xacro:arg name="hand"   default="false" /> <!-- Should a franka_gripper be mounted at the flange?" -->
-  <xacro:arg name="gazebo" default="false" /> <!-- Is the robot being simulated in gazebo?" -->
+  <!-- Name of this panda -->
+  <xacro:arg name="arm_id" default="panda" />
+  <!-- Should a franka_gripper be mounted at the flange?" -->
+  <xacro:arg name="hand" default="false" />
+  <!-- Is the robot being simulated in gazebo?" -->
+  <xacro:arg name="gazebo" default="false" />
 
   <xacro:unless value="$(arg gazebo)">
     <!-- Create a URDF for a real hardware -->

--- a/franka_description/robots/panda_arm.urdf.xacro
+++ b/franka_description/robots/panda_arm.urdf.xacro
@@ -7,6 +7,8 @@
   <xacro:arg name="hand" default="false" />
   <!-- Is the robot being simulated in gazebo?" -->
   <xacro:arg name="gazebo" default="false" />
+  <!-- Namespace of robot in Gazebo/ROS (default: empty) -->
+  <xacro:arg name="ns" default="" />
 
   <xacro:unless value="$(arg gazebo)">
     <!-- Create a URDF for a real hardware -->
@@ -61,7 +63,7 @@
 
     <gazebo>
       <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-        <robotNamespace>$(arg arm_id)</robotNamespace>
+        <robotNamespace>$(arg ns)</robotNamespace>
         <controlPeriod>0.001</controlPeriod>
         <robotSimType>franka_gazebo/FrankaHWSim</robotSimType>
       </plugin>

--- a/franka_description/robots/panda_gazebo.xacro
+++ b/franka_description/robots/panda_gazebo.xacro
@@ -8,7 +8,7 @@
   <!-- || PandaRobot With Retrieval of Feasible Parameters Using    || -->
   <!-- || Penalty-Based Optimization                                || -->
   <!-- || by: Claudio Gaz, Marco Cognetti, Alexander Oliva,         || -->
-  <!-- || Paolo Robuffo Giordano, Alessandro de Lucaa               || -->
+  <!-- || Paolo Robuffo Giordano, Alessandro de Luca                || -->
   <!-- =============================================================== -->
 
   <xacro:macro name="panda_arm" params="arm_id:='panda'">

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="ns" default="" doc="Namespace to launch the Gazebo robot in" />
 
   <!-- Gazebo & GUI Configuration -->
   <arg name="gazebo"      default="true"  doc="Should the gazebo simulation be launched? Use false in case if you want to include this file and launch gazebo yourself" />
@@ -37,65 +38,10 @@
     <arg name="use_sim_time" value="true"/>
   </include>
 
-  <group ns="$(arg arm_id)">
-    <param name="robot_description"
-           command="xacro $(find franka_description)/robots/panda_arm.urdf.xacro
-                    gazebo:=true
-                    hand:=$(arg use_gripper)
-                    arm_id:=$(arg arm_id)
-                    ns:=$(arg arm_id)
-                    xyz:='$(arg x) $(arg y) $(arg z)'
-                    rpy:='$(arg roll) $(arg pitch) $(arg yaw)'">
-    </param>
 
-    <rosparam file="$(find franka_gazebo)/config/franka_hw_sim.yaml" subst_value="true" />
-    <rosparam file="$(find franka_gazebo)/config/sim_controllers.yaml" subst_value="true" />
-
-    <arg name="unpause" value="$(eval '' if arg('paused') else '-unpause')" />
-    <node name="$(arg arm_id)_model_spawner"
-          pkg="gazebo_ros"
-          type="spawn_model"
-          args="-param robot_description -urdf -model $(arg arm_id) $(arg unpause)
-                $(arg initial_joint_positions)
-                "/>
-
-    <!-- Spawn required ROS controllers -->
-    <node pkg="controller_manager"
-          type="spawner"
-          name="$(arg arm_id)_gripper_spawner"
-          if="$(arg use_gripper)"
-          args="franka_gripper"
-          respawn="false"
-    />
-
-    <node pkg="controller_manager"
-          type="spawner"
-          name="$(arg arm_id)_controller_spawner"
-          respawn="false" output="screen"
-          args="franka_state_controller $(arg controller)"
-    />
-
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-    <node name="joint_state_publisher" type="joint_state_publisher" pkg="joint_state_publisher">
-      <rosparam param="source_list">[franka_state_controller/joint_states, franka_gripper/joint_states] </rosparam>
-      <param name="rate" value="30"/>
-    </node>
-    <node name="joint_state_desired_publisher" type="joint_state_publisher" pkg="joint_state_publisher">
-      <rosparam param="source_list">[franka_state_controller/joint_states_desired, franka_gripper/joint_states] </rosparam>
-      <param name="rate" value="30"/>
-      <remap from="joint_states" to="joint_states_desired" />
-    </node>
-
-    <!-- Start only if cartesian_impedance_example_controller -->
-    <node name="interactive_marker"
-          pkg="franka_example_controllers"
-          type="interactive_marker.py"
-          if="$(eval arg('controller') == 'cartesian_impedance_example_controller')">
-      <param name="link_name" value="$(arg arm_id)_link0" />
-      <remap to="cartesian_impedance_example_controller/equilibrium_pose" from="equilibrium_pose" />
-    </node>
-
-  </group>
+  <!-- Depending on whether the namespace is empty or not, don't start in a namespace (or do) -->
+  <include file="$(dirname)/panda_ns.launch.xml" pass_all_args="true" if="$(eval arg('ns') == '')" />
+  <include file="$(dirname)/panda_ns.launch.xml" pass_all_args="true" if="$(eval arg('ns') != '')" ns="$(arg ns)" />
 
   <node  pkg="rviz" type="rviz" output="screen" name="rviz" args="-d $(find franka_gazebo)/config/franka_sim_description_with_marker.rviz" if="$(arg rviz)"/>
 

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -43,6 +43,7 @@
                     gazebo:=true
                     hand:=$(arg use_gripper)
                     arm_id:=$(arg arm_id)
+                    ns:=$(arg arm_id)
                     xyz:='$(arg x) $(arg y) $(arg z)'
                     rpy:='$(arg roll) $(arg pitch) $(arg yaw)'">
     </param>

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -31,6 +31,7 @@
 
   <include file="$(find gazebo_ros)/launch/empty_world.launch" if="$(arg gazebo)">
     <arg name="world_name" value="$(arg world)"/>
+    <!-- Always start in paused mode, and only unpause when spawning the model -->
     <arg name="paused" value="true"/>
     <arg name="gui" value="$(eval not arg('headless'))"/>
     <arg name="use_sim_time" value="true"/>
@@ -49,23 +50,13 @@
     <rosparam file="$(find franka_gazebo)/config/franka_hw_sim.yaml" subst_value="true" />
     <rosparam file="$(find franka_gazebo)/config/sim_controllers.yaml" subst_value="true" />
 
+    <arg name="unpause" value="$(eval '' if arg('paused') else '-unpause')" />
     <node name="$(arg arm_id)_model_spawner"
           pkg="gazebo_ros"
           type="spawn_model"
-          if="$(arg paused)"
-          args="-param robot_description -urdf -model $(arg arm_id)
+          args="-param robot_description -urdf -model $(arg arm_id) $(arg unpause)
                 $(arg initial_joint_positions)
-                ">
-    </node>
-    <node name="$(arg arm_id)_model_spawner"
-          pkg="gazebo_ros"
-          type="spawn_model"
-          unless="$(arg paused)"
-          args="-param robot_description -urdf -model $(arg arm_id) -unpause
-                $(arg initial_joint_positions)
-                ">
-    </node>
-
+                "/>
 
     <!-- Spawn required ROS controllers -->
     <node pkg="controller_manager"

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -74,8 +74,6 @@
           args="franka_state_controller $(arg controller)"
     />
 
-    <remap to="cartesian_impedance_example_controller/equilibrium_pose" from="equilibrium_pose" />
-
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
     <node name="joint_state_publisher" type="joint_state_publisher" pkg="joint_state_publisher">
       <rosparam param="source_list">[franka_state_controller/joint_states, franka_gripper/joint_states] </rosparam>
@@ -93,6 +91,7 @@
           type="interactive_marker.py"
           if="$(eval arg('controller') == 'cartesian_impedance_example_controller')">
       <param name="link_name" value="$(arg arm_id)_link0" />
+      <remap to="cartesian_impedance_example_controller/equilibrium_pose" from="equilibrium_pose" />
     </node>
 
   </group>

--- a/franka_gazebo/launch/panda.launch
+++ b/franka_gazebo/launch/panda.launch
@@ -36,6 +36,9 @@
     <arg name="paused" value="true"/>
     <arg name="gui" value="$(eval not arg('headless'))"/>
     <arg name="use_sim_time" value="true"/>
+    <!-- Remap both, arm and gripper joint states to default ROS topic joint_states -->
+    <remap from="franka_state_controller/joint_states" to="joint_states" />
+    <remap from="franka_gripper/joint_states" to="joint_states" />
   </include>
 
 

--- a/franka_gazebo/launch/panda_ns.launch.xml
+++ b/franka_gazebo/launch/panda_ns.launch.xml
@@ -48,11 +48,6 @@
       <rosparam param="source_list">[franka_state_controller/joint_states, franka_gripper/joint_states] </rosparam>
       <param name="rate" value="30"/>
     </node>
-    <node name="joint_state_desired_publisher" type="joint_state_publisher" pkg="joint_state_publisher">
-      <rosparam param="source_list">[franka_state_controller/joint_states_desired, franka_gripper/joint_states] </rosparam>
-      <param name="rate" value="30"/>
-      <remap from="joint_states" to="joint_states_desired" />
-    </node>
 
     <!-- Start only if cartesian_impedance_example_controller -->
     <node name="interactive_marker"

--- a/franka_gazebo/launch/panda_ns.launch.xml
+++ b/franka_gazebo/launch/panda_ns.launch.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<launch>
+
+    <!-- This is a helper launch file for panda.launch
+         As roslaunch doesn't allow for empty ns arguments and to avoid code duplication,
+         we factored out code here that should run either in or out a namespace.
+         All arguments are simply inherited from the parent launch file.
+    -->
+    <param name="robot_description"
+           command="xacro $(find franka_description)/robots/panda_arm.urdf.xacro
+                    gazebo:=true
+                    hand:=$(arg use_gripper)
+                    arm_id:=$(arg arm_id)
+                    ns:=$(arg ns)
+                    xyz:='$(arg x) $(arg y) $(arg z)'
+                    rpy:='$(arg roll) $(arg pitch) $(arg yaw)'">
+    </param>
+
+    <rosparam file="$(find franka_gazebo)/config/franka_hw_sim.yaml" subst_value="true" />
+    <rosparam file="$(find franka_gazebo)/config/sim_controllers.yaml" subst_value="true" />
+
+    <arg name="unpause" value="$(eval '' if arg('paused') else '-unpause')" />
+    <node name="$(arg arm_id)_model_spawner"
+          pkg="gazebo_ros"
+          type="spawn_model"
+          args="-param robot_description -urdf -model $(arg arm_id) $(arg unpause)
+                $(arg initial_joint_positions)
+                "/>
+
+    <!-- Spawn required ROS controllers -->
+    <node pkg="controller_manager"
+          type="spawner"
+          name="$(arg arm_id)_gripper_spawner"
+          if="$(arg use_gripper)"
+          args="franka_gripper"
+          respawn="false"
+    />
+
+    <node pkg="controller_manager"
+          type="spawner"
+          name="$(arg arm_id)_controller_spawner"
+          respawn="false" output="screen"
+          args="franka_state_controller $(arg controller)"
+    />
+
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+    <node name="joint_state_publisher" type="joint_state_publisher" pkg="joint_state_publisher">
+      <rosparam param="source_list">[franka_state_controller/joint_states, franka_gripper/joint_states] </rosparam>
+      <param name="rate" value="30"/>
+    </node>
+    <node name="joint_state_desired_publisher" type="joint_state_publisher" pkg="joint_state_publisher">
+      <rosparam param="source_list">[franka_state_controller/joint_states_desired, franka_gripper/joint_states] </rosparam>
+      <param name="rate" value="30"/>
+      <remap from="joint_states" to="joint_states_desired" />
+    </node>
+
+    <!-- Start only if cartesian_impedance_example_controller -->
+    <node name="interactive_marker"
+          pkg="franka_example_controllers"
+          type="interactive_marker.py"
+          if="$(eval arg('controller') == 'cartesian_impedance_example_controller')">
+      <param name="link_name" value="$(arg arm_id)_link0" />
+      <remap to="cartesian_impedance_example_controller/equilibrium_pose" from="equilibrium_pose" />
+    </node>
+
+</launch>

--- a/franka_gazebo/launch/panda_ns.launch.xml
+++ b/franka_gazebo/launch/panda_ns.launch.xml
@@ -44,10 +44,6 @@
     />
 
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-    <node name="joint_state_publisher" type="joint_state_publisher" pkg="joint_state_publisher">
-      <rosparam param="source_list">[franka_state_controller/joint_states, franka_gripper/joint_states] </rosparam>
-      <param name="rate" value="30"/>
-    </node>
 
     <!-- Start only if cartesian_impedance_example_controller -->
     <node name="interactive_marker"

--- a/franka_gazebo/test/launch/panda-gazebo.urdf
+++ b/franka_gazebo/test/launch/panda-gazebo.urdf
@@ -7,7 +7,7 @@
   <!-- || PandaRobot With Retrieval of Feasible Parameters Using    || -->
   <!-- || Penalty-Based Optimization                                || -->
   <!-- || by: Claudio Gaz, Marco Cognetti, Alexander Oliva,         || -->
-  <!-- || Paolo Robuffo Giordano,Alessandro de Lucaa third-party    || -->
+  <!-- || Paolo Robuffo Giordano, Alessandro de Luca third-party    || -->
   <!-- =============================================================== -->
   <link name="world"/>
   <joint name="panda_joint_panda_mount" type="fixed">


### PR DESCRIPTION
Re-publishing `joint_states` via `joint_state_publisher` (a python app) is highly inefficient. 
IMO remapping would be the right way to go instead - as long nobody needs the published topics on the namespace 
`franka_state_controller` / `franka_gripper`. 
Also, I dropped re-publishing `joint_states_desired` completely.
@gollth and @rickstaa, what do you think?

As this is just a draft and builds on https://github.com/frankaemika/franka_ros/pull/187, I filed the changes in my fork for now.